### PR TITLE
Issue #345 fixed

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -89,6 +89,7 @@ use Monolog\Logger;
  *   - [bubble]: bool, defaults to true
  *
  * - redis:
+ *   - type: redis
  *   - redis:
  *      - id: optional if host is given
  *      - host: 127.0.0.1


### PR DESCRIPTION
Just updated the reference by adding `type` under `monolog.handlers.redis`

```
        redis:
            type: redis
            redis:
                #id: optional if host is given
                host: 127.0.0.1
                password: null
                port: 6379
                database: 0
                key_name: monolog_redis
```